### PR TITLE
build: fix errors on `pnpm preview`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@stoplight/json-schema-viewer": "^4.16.1",
     "@stoplight/mosaic": "^1.53.4",
+    "@types/prismjs": "^1.26.4",
+    "prismjs": "^1.29.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vite-plugin-prismjs": "^0.0.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ devDependencies:
   vite:
     specifier: ^5.4.1
     version: 5.4.1
+  vite-plugin-prismjs:
+    specifier: ^0.0.11
+    version: 0.0.11(prismjs@1.29.0)
 
 packages:
 
@@ -1476,6 +1479,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /babel-plugin-prismjs@2.1.0(prismjs@1.29.0):
+    resolution: {integrity: sha512-ehzSKYfeAz4U78zi/sfwsjDPlq0LvDKxNefcZTJ/iKBu+plsHsLqZhUeGf1+82LAcA35UZGbU6ksEx2Utphc/g==}
+    peerDependencies:
+      prismjs: ^1.18.0
+    dependencies:
+      prismjs: 1.29.0
+    dev: true
+
   /bail@1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
     dev: false
@@ -2693,7 +2704,6 @@ packages:
   /prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
-    dev: false
 
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3284,6 +3294,17 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
     dev: false
+
+  /vite-plugin-prismjs@0.0.11(prismjs@1.29.0):
+    resolution: {integrity: sha512-20NBQxg/zH+3FTrlU6BQTob720xkuXNYtrx7psAQ4E6pMcRDeLEK77QU9kXURU587+f2To7ASH1JVTGbXVV/vQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@babel/core': 7.25.2
+      babel-plugin-prismjs: 2.1.0(prismjs@1.29.0)
+    transitivePeerDependencies:
+      - prismjs
+      - supports-color
+    dev: true
 
   /vite@5.4.1:
     resolution: {integrity: sha512-1oE6yuNXssjrZdblI9AfBbHCC41nnyoVoEZxQnID6yvQZAFBzxxkqoFLtHUMkYunL8hwOLEjgTuxpkRxvba3kA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ dependencies:
   '@stoplight/mosaic':
     specifier: ^1.53.4
     version: 1.53.4(react-dom@18.3.1)(react@18.3.1)
+  '@types/prismjs':
+    specifier: ^1.26.4
+    version: 1.26.4
+  prismjs:
+    specifier: ^1.29.0
+    version: 1.29.0
   react:
     specifier: ^18.3.1
     version: 18.3.1
@@ -1243,6 +1249,10 @@ packages:
 
   /@types/parse5@6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
+    dev: false
+
+  /@types/prismjs@1.26.4:
+    resolution: {integrity: sha512-rlAnzkW2sZOjbqZ743IHUhFcvzaGbqijwOu8QZnZCjfQzBqFE3s4lOTJEsxikImav9uzz/42I+O7YUs1mWgMlg==}
     dev: false
 
   /@types/prop-types@15.7.13:

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
+import "prismjs";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,33 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import prismjs from "vite-plugin-prismjs"
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: [
+          [
+            "prismjs",
+            {
+              languages: ["javascript"],
+              plugins: [],
+              theme: "twilight",
+              css: false,
+            },
+          ],
+        ],
+      },
+    }),
+    prismjs({
+      languages: ["javascript"],
+      plugins: [],
+      theme: "twilight",
+      css: false,
+    }),
+  ],
+  build: {
+    commonjsOptions: { transformMixedEsModules: true },
+  }
 })


### PR DESCRIPTION
Goal is to be able to:
- Run `pnpm build` (succeeds currently)
- Run `pnpm preview` (initially errored on `require is not defined`, now erroring on `prismjs is not defined`)
- Deploy static site to gh-pages (per guide here https://vite.dev/guide/static-deploy.html)

References:
- https://github.com/stoplightio/json-schema-viewer/issues/207
- https://stackoverflow.com/questions/77421447/how-to-solve-require-is-not-defined-in-vite
- https://github.com/code-farmer-i/vite-plugin-prismjs/issues/1