### PR TITLE
feat: toggle hardcoded schema versions

### DIFF
--- a/api/useQuerySchemas.ts
+++ b/api/useQuerySchemas.ts
@@ -1,19 +1,27 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import axios from "axios";
 
 const DIGITAL_PLANNING_DATA_SCHEMAS_JSON_URL =
-  "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.0/schema.json";
+  "https://theopensystemslab.github.io/digital-planning-data-schemas";
 
-const useQuerySchemas = () => {
+// TODO: type the version more strictly
+const useQuerySchemas = (
+  version: string,
+  options?: Readonly<Omit<UseQueryOptions<unknown>, "queryKey" | "queryFn">>
+) => {
   const fetchFn = async (url: string) => {
     const response = await axios.get(url);
     return response.data;
   };
 
   return useQuery({
-    queryKey: ["schemas"],
-    queryFn: () => fetchFn(DIGITAL_PLANNING_DATA_SCHEMAS_JSON_URL),
+    queryKey: ["schemas", version],
+    queryFn: () =>
+      fetchFn(
+        `${DIGITAL_PLANNING_DATA_SCHEMAS_JSON_URL}/${version}/schema.json`
+      ),
     staleTime: 1000 * 60 * 10, // cache for 10 minutes
+    ...options,
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.59.15",
     "@types/prismjs": "^1.26.4",
     "axios": "^1.7.7",
+    "formik": "^2.4.6",
     "prismjs": "^1.29.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   axios:
     specifier: ^1.7.7
     version: 1.7.7
+  formik:
+    specifier: ^2.4.6
+    version: 2.4.6(react@18.3.1)
   prismjs:
     specifier: ^1.29.0
     version: 1.29.0
@@ -1535,6 +1538,13 @@ packages:
       '@types/unist': 2.0.11
     dev: false
 
+  /@types/hoist-non-react-statics@3.3.5:
+    resolution: {integrity: sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==}
+    dependencies:
+      '@types/react': 18.3.3
+      hoist-non-react-statics: 3.3.2
+    dev: false
+
   /@types/js-cookie@2.2.7:
     resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
     dev: false
@@ -2050,6 +2060,11 @@ packages:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
 
+  /deepmerge@2.2.1:
+    resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -2364,6 +2379,22 @@ packages:
   /format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+    dev: false
+
+  /formik@2.4.6(react@18.3.1):
+    resolution: {integrity: sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.5
+      deepmerge: 2.2.1
+      hoist-non-react-statics: 3.3.2
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      react: 18.3.1
+      react-fast-compare: 2.0.4
+      tiny-warning: 1.0.3
+      tslib: 2.7.0
     dev: false
 
   /fsevents@2.3.3:
@@ -2748,6 +2779,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
     dev: true
+
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
 
   /lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
@@ -3208,6 +3243,10 @@ packages:
       scheduler: 0.23.2
     dev: false
 
+  /react-fast-compare@2.0.4:
+    resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
+    dev: false
+
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
     dev: false
@@ -3538,6 +3577,10 @@ packages:
   /throttle-debounce@3.0.1:
     resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
     engines: {node: '>=10'}
+    dev: false
+
+  /tiny-warning@1.0.3:
+    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
 
   /to-fast-properties@2.0.0:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,58 +1,55 @@
-import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 
 import { JsonSchemaViewer } from "@stoplight/json-schema-viewer";
-import { Provider as MosaicProvider, injectStyles } from "@stoplight/mosaic";
+import { injectStyles } from "@stoplight/mosaic";
+import { useFormik } from "formik";
 import useQuerySchemas from "./../api/useQuerySchemas";
+
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Header from "./components/Header";
 
 const App = () => {
   injectStyles();
 
   const { data: schema, isLoading, isError } = useQuerySchemas();
 
+  const formik = useFormik({
+    initialValues: {
+      version: "",
+    },
+    onSubmit: () => console.log("hi"),
+  });
+
   return (
-    <Box py={2} style={{ maxWidth: 1000 }} mx="auto">
-      <Typography textAlign="center" variant="h2">
-        Digital planning data schemas
-      </Typography>
-      <Typography pt={4} maxWidth={800} mx='auto'>
-        Digital Planning Data schemas aim to encourage more interoperability and
-        consistency between systems by offering a central, version controlled
-        specification for documenting and validating planning data.
-      </Typography>
-      <MosaicProvider>
-        <Box
-          p={6}
-          my={4}
-          maxWidth={800}
-          style={{
-            borderRadius: 2,
-            backgroundColor: "#fff5ef",
-          }}
-          mx="auto"
-        >
-          {isLoading ? (
-            <Typography>Loading...</Typography>
-          ) : (
-            <>
-              <Typography pb={2}>{schema.$id}</Typography>
-              <JsonSchemaViewer
-                name="Digital planning data schemas"
-                schema={schema}
-                hideTopBar={false}
-                emptyText="No schema defined"
-                expanded={true}
-                defaultExpandedDepth={0}
-                renderRootTreeLines={true}
-              />
-            </>
-          )}
-          {isError && (
-            <Typography pt={4}>Sorry, please try again later.</Typography>
-          )}
-        </Box>
-      </MosaicProvider>
-    </Box>
+    <Header>
+      {isLoading ? (
+        <Typography>Loading...</Typography>
+      ) : (
+        <>
+          <form onSubmit={formik.handleSubmit}>
+            <InputLabel>Version</InputLabel>
+            <Select>
+              <MenuItem>A version</MenuItem>
+            </Select>
+          </form>
+          <Typography pb={2}>{schema.$id}</Typography>
+          <JsonSchemaViewer
+            name="Digital planning data schemas"
+            schema={schema}
+            hideTopBar={false}
+            emptyText="No schema defined"
+            expanded={true}
+            defaultExpandedDepth={0}
+            renderRootTreeLines={true}
+          />
+        </>
+      )}
+      {isError && (
+        <Typography pt={4}>Sorry, please try again later.</Typography>
+      )}
+    </Header>
   );
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import Typography from "@mui/material/Typography";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { JsonSchemaViewer } from "@stoplight/json-schema-viewer";
 import { injectStyles } from "@stoplight/mosaic";
@@ -8,18 +9,30 @@ import useQuerySchemas from "./../api/useQuerySchemas";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
+import { useState } from "react";
 import Header from "./components/Header";
+
+// TODO: grab this programatically instead of hard-coding
+const LATEST_WORKING_VERSION = "v0.7.0";
 
 const App = () => {
   injectStyles();
+  const queryClient = useQueryClient();
+  const [selectedVersion, setSelectedVersion] = useState(
+    LATEST_WORKING_VERSION
+  );
 
-  const { data: schema, isLoading, isError } = useQuerySchemas();
+  const {
+    data: schema,
+    isLoading,
+    isError,
+  } = useQuerySchemas(selectedVersion, { retry: false });
 
   const formik = useFormik({
     initialValues: {
-      version: "",
+      version: selectedVersion,
     },
-    onSubmit: () => console.log("hi"),
+    onSubmit: (values) => setSelectedVersion(values.version),
   });
 
   return (
@@ -29,21 +42,51 @@ const App = () => {
       ) : (
         <>
           <form onSubmit={formik.handleSubmit}>
-            <InputLabel>Version</InputLabel>
-            <Select>
-              <MenuItem>A version</MenuItem>
+            <InputLabel shrink id="select-version-label">
+              Version
+            </InputLabel>
+            <Select
+              sx={{ marginBottom: 4 }}
+              labelId="select-version-label"
+              defaultValue={selectedVersion}
+              id="select-version"
+              onChange={(e) => {
+                queryClient.invalidateQueries({
+                  queryKey: ["schemas", selectedVersion],
+                });
+                formik.setFieldValue("version", e.target.value, false);
+                formik.submitForm();
+              }}
+              value={formik.values.version}
+            >
+              // TODO: add query to populate with a list of possible versions
+              <MenuItem value={"v0.7.1"}>v0.7.1</MenuItem>
+              <MenuItem value={"v0.7.0"}>v0.7.0</MenuItem>
+              <MenuItem value={"v0.6.0"}>v0.6.0</MenuItem>
+              <MenuItem value={"v0.5.0"}>v0.5.0</MenuItem>
+              <MenuItem value={"v0.4.0"}>v0.4.0</MenuItem>
+              <MenuItem value={"v0.4.1"}>v0.4.1</MenuItem>
+              <MenuItem value={"v0.3.0"}>v0.3.0</MenuItem>
+              <MenuItem value={"v0.2.3"}>v0.2.3</MenuItem>
+              <MenuItem value={"v0.2.2"}>v0.2.2</MenuItem>
+              <MenuItem value={"v0.2.1"}>v0.2.1</MenuItem>
+              <MenuItem value={"v0.2.0"}>v0.2.0</MenuItem>
+              <MenuItem value={"v0.1.2"}>v0.1.2</MenuItem>
+              <MenuItem value={"v0.1.1"}>v0.1.1</MenuItem>
+              <MenuItem value={"v0.1.0"}>v0.1.0</MenuItem>
             </Select>
           </form>
-          <Typography pb={2}>{schema.$id}</Typography>
-          <JsonSchemaViewer
-            name="Digital planning data schemas"
-            schema={schema}
-            hideTopBar={false}
-            emptyText="No schema defined"
-            expanded={true}
-            defaultExpandedDepth={0}
-            renderRootTreeLines={true}
-          />
+          {!isError && (
+            <JsonSchemaViewer
+              name="Digital planning data schemas"
+              schema={schema}
+              hideTopBar={false}
+              emptyText="No schema defined"
+              expanded={true}
+              defaultExpandedDepth={0}
+              renderRootTreeLines={true}
+            />
+          )}
         </>
       )}
       {isError && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,39 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+
+import { Provider as MosaicProvider, injectStyles } from "@stoplight/mosaic";
+
+import { ComponentProps } from "react";
+
+const Header = ({ children }: ComponentProps<"header">)  => {
+  injectStyles();
+
+  return (
+    <Box p={2} style={{ maxWidth: 1000 }} mx="auto">
+      <Typography textAlign="center" variant="h2">
+        Digital planning data schemas
+      </Typography>
+      <Typography pt={4} maxWidth={800} mx="auto">
+        Digital Planning Data schemas aim to encourage more interoperability and
+        consistency between systems by offering a central, version controlled
+        specification for documenting and validating planning data.
+      </Typography>
+      <MosaicProvider>
+        <Box
+          p={6}
+          my={4}
+          maxWidth={800}
+          style={{
+            borderRadius: 2,
+            backgroundColor: "#fff5ef",
+          }}
+          mx="auto"
+        >
+          {children}
+        </Box>
+      </MosaicProvider>
+    </Box>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
Linked with issue: [Support dynamic querying...](https://github.com/theopensystemslab/digital-planning-data-schemas-docs/issues/4)

⚠️ This currently just uses a hardcoded list of versions in the dropdown. 

### Next steps

Next steps are to grab these programatically to populate the dropdown!

I think we should be able to do this with the GH api: [GET list releases](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases). It returns an array of items, where one of the item's keys is `tag_name`, containing the version strings we are currently using in the dropdown.

### Screenshots

![Screenshot 2024-11-27 at 18 34 41](https://github.com/user-attachments/assets/4f8f22f8-1a86-4afe-a9cf-6bb0a76f02dc)
